### PR TITLE
test: add basic level of testing to project

### DIFF
--- a/dnsmasq-ext/external.host
+++ b/dnsmasq-ext/external.host
@@ -6,10 +6,10 @@
 # Goal is to have each project to operate in their own IP range.
 # Services IP must match HostIP used in that project's compose file.
 
-# # https://github.com/scoremedia/proj1
-# 127.10.0.1       db.proj1.test
-# 127.10.0.2       redis.proj2.test
+# https://github.com/scoremedia/proj1
+127.10.0.1       db.proj1.test
+#127.10.0.2       redis.proj2.test
 
-# # https://github.com/scoremedia/proj2
-# 127.11.0.1       db.proj1.test
+# https://github.com/scoremedia/proj2
+127.11.0.1       db.proj2.test
 # 127.11.0.2       redis.proj2.test

--- a/tests/example_projects/proj1/Dockerfile
+++ b/tests/example_projects/proj1/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+ENV PACKAGES "postgresql-client curl bash"
+
+RUN apk add --no-cache $PACKAGES

--- a/tests/example_projects/proj1/docker-compose.yml
+++ b/tests/example_projects/proj1/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+
+services:
+  web:
+    environment:
+      - VIRTUAL_HOST=web.proj1.test
+    dns: 172.25.0.253
+    image: vad1mo/hello-world-rest
+
+  db:
+    image: postgres
+    ports:
+      - 127.10.0.1:5432:5432
+    environment:
+      - POSTGRES_PASSWORD=example
+      - VIRTUAL_HOST_WITH_HOSTIP=db.proj1.test
+    dns: 172.25.0.253
+
+  runner:
+    build: .
+    dns: 172.25.0.253
+
+networks:
+  default:
+    external:
+      name: dcdc_default

--- a/tests/example_projects/proj2/Dockerfile
+++ b/tests/example_projects/proj2/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+ENV PACKAGES "postgresql-client curl bash"
+
+RUN apk add --no-cache $PACKAGES

--- a/tests/example_projects/proj2/docker-compose.yml
+++ b/tests/example_projects/proj2/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+
+services:
+  web:
+    environment:
+      - VIRTUAL_HOST=web.proj2.test
+    dns: 172.25.0.253
+    image: vad1mo/hello-world-rest
+
+  db:
+    image: postgres
+    ports:
+      - 127.11.0.1:5432:5432
+    environment:
+      - POSTGRES_PASSWORD=example
+      - VIRTUAL_HOST_WITH_HOSTIP=db.proj2.test
+    dns: 172.25.0.253
+
+  runner:
+    build: .
+    dns: 172.25.0.253
+
+networks:
+  default:
+    external:
+      name: dcdc_default

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Requires docker-compose, curl and psql
+
+FILE_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >& /dev/null && pwd)"
+PROJECT_DIR=$FILE_DIR/..
+
+NO_COLOUR='\033[0m'
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+
+run () {
+  echo " |-> Running: '$1'"
+  ip_address=$(eval $1 | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
+
+  if [ $? -eq 0 ]
+  then
+    echo -e "${GREEN} |-> Passed (with IP address: $ip_address) ${NO_COLOUR}"
+  else
+    echo -e "${RED} |-> Failed (no IP address found) ${NO_COLOUR}"
+  fi
+}
+
+
+# -- TEST SETUP --
+cd $PROJECT_DIR
+
+echo "-> Starting up dcdc (assuming .bin/setup has ran)"
+docker-compose build >& /dev/null
+docker-compose up -d >& /dev/null
+
+echo "-> Starting up proj1 web and db services"
+cd $PROJECT_DIR/tests/example_projects/proj1
+docker-compose build web db >& /dev/null
+docker-compose up -d web db >& /dev/null
+
+echo "-> Starting up proj2 web and db services"
+cd $PROJECT_DIR/tests/example_projects/proj2
+docker-compose build web db >& /dev/null
+docker-compose up -d web db >& /dev/null
+
+echo "-> Sleeping 10s while they start"
+sleep 10
+
+# -- TESTING ACCESS TO WEB SERVICE --
+
+echo "-> Accessing proj1:web service (web.proj1.test) from external host (outside docker)"
+run 'curl -s -L -k web.proj1.test'
+
+echo "-> Accessing proj2:web service (web.proj2.test) from external host (outside docker)"
+run 'curl -s -L -k web.proj2.test'
+
+echo "-> Accessing proj1:web service (web.proj1.test) from proj2:runner container (inside docker)"
+run 'docker-compose run runner curl -s -L -k web.proj1.test'
+
+echo "-> Accessing proj2:web service (web.proj2.test) from proj2:runner container (inside docker)"
+run 'docker-compose run runner curl -s -L -k web.proj2.test'
+
+# -- TESTING ACCESS TO DB SERVICE --
+
+echo "-> Accessing proj1:db service (db.proj1.test) from external host (outside docker)"
+run 'PGPASSWORD=example psql -U postgres -h db.proj1.test -c "SELECT inet_server_addr();"'
+
+echo "-> Accessing proj2:db service (db.proj2.test) from external host (outside docker)"
+run 'PGPASSWORD=example psql -U postgres -h db.proj2.test -c "SELECT inet_server_addr();"'
+
+echo "-> Accessing proj1:db service (db.proj1.test) from proj2:runner container (inside docker)"
+run 'docker-compose run -e PGPASSWORD=example runner psql -U postgres -h db.proj1.test -c "SELECT inet_server_addr();"'
+
+echo "-> Accessing proj2:db service (db.proj2.test) from proj2:runner container (inside docker)"
+run 'docker-compose run -e PGPASSWORD=example runner psql -U postgres -h db.proj2.test -c "SELECT inet_server_addr();"'
+
+# -- TEST TEARDOWN --
+
+echo "-> Shutting down proj2 web and db services"
+cd $PROJECT_DIR/tests/example_projects/proj2
+docker-compose down >& /dev/null
+
+echo "-> Shutting down proj1 web and db services"
+cd $PROJECT_DIR/tests/example_projects/proj1
+docker-compose down >& /dev/null
+
+echo "-> Shutting down dcdc"
+cd $PROJECT_DIR
+docker-compose down >& /dev/null


### PR DESCRIPTION
This commit adds a basic level of test to the project. It is a script that spins up two projects (identical) along with dcdc and then performs some quick accessibility checks via curl and psql from outside and internal to the docker network.

The dnsmasq-ext/external.host is updated to better reflect the default state of the tests.

-----

Example output:

```
-> Starting up dcdc (assuming .bin/setup has ran)
-> Starting up proj1 web and db services
-> Starting up proj2 web and db services
-> Sleeping 10s while they start
-> Accessing proj1:web service (web.proj1.test) from external host (outside docker)
 |-> Running: 'curl -s -L -k web.proj1.test'
 |-> Passed (with IP address: 172.25.0.3)
-> Accessing proj2:web service (web.proj2.test) from external host (outside docker)
 |-> Running: 'curl -s -L -k web.proj2.test'
 |-> Passed (with IP address: 172.25.0.4)
-> Accessing proj1:web service (web.proj1.test) from proj2:runner container (inside docker)
 |-> Running: 'docker-compose run runner curl -s -L -k web.proj1.test'
 |-> Passed (with IP address: 172.25.0.3)
-> Accessing proj2:web service (web.proj2.test) from proj2:runner container (inside docker)
 |-> Running: 'docker-compose run runner curl -s -L -k web.proj2.test'
 |-> Passed (with IP address: 172.25.0.4)
-> Accessing proj1:db service (db.proj1.test) from external host (outside docker)
 |-> Running: 'PGPASSWORD=example psql -U postgres -h db.proj1.test -c "SELECT inet_server_addr();"'
 |-> Passed (with IP address: 172.25.0.2)
-> Accessing proj2:db service (db.proj2.test) from external host (outside docker)
 |-> Running: 'PGPASSWORD=example psql -U postgres -h db.proj2.test -c "SELECT inet_server_addr();"'
 |-> Passed (with IP address: 172.25.0.5)
-> Accessing proj1:db service (db.proj1.test) from proj2:runner container (inside docker)
 |-> Running: 'docker-compose run -e PGPASSWORD=example runner psql -U postgres -h db.proj1.test -c "SELECT inet_server_addr();"'
 |-> Passed (with IP address: 172.25.0.2)
-> Accessing proj2:db service (db.proj2.test) from proj2:runner container (inside docker)
 |-> Running: 'docker-compose run -e PGPASSWORD=example runner psql -U postgres -h db.proj2.test -c "SELECT inet_server_addr();"'
 |-> Passed (with IP address: 172.25.0.5)
-> Shutting down proj2 web and db services
-> Shutting down proj1 web and db services
-> Shutting down dcdc
```